### PR TITLE
Adding OSS snapshot repo, mainly for jenkins client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,21 @@
       </dependency>
     </dependencies>
     <repositories>
-        <repository>
-            <id>jcenter</id>
-            <url>https://jcenter.bintray.com/</url>
-        </repository>
+      <repository>
+        <id>jcenter</id>
+        <url>https://jcenter.bintray.com/</url>
+      </repository>
+      <repository>
+        <id>sonatype.oss.snapshots</id>
+        <name>Sonatype OSS Snapshot Repository</name>
+        <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+        <releases>
+          <enabled>false</enabled>
+        </releases>
+        <snapshots>
+          <enabled>true</enabled>
+        </snapshots>
+      </repository>
     </repositories>
 
     <build>


### PR DESCRIPTION
@aliok @wtrocki @odra 

Be able to use latest SNAPSHOT from our jenkins-client dependency. @khmarbaise was kind enough to deploy a snapshot to sonatypes OSS repo