### PR TITLE
AGDIGGER-73 Allow parameters to be defined in jobs and update jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <slf4j.api.version>1.7.21</slf4j.api.version>
         <slf4j-log4j12.version>1.7.21</slf4j-log4j12.version>
         <assertj-core.version>3.6.1</assertj-core.version>
+        <commons-collections4.version>4.0</commons-collections4.version>
     </properties>
 
     <scm>
@@ -67,6 +68,12 @@
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j-log4j12.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${commons-collections4.version}</version>
+        </dependency>
+
 
         <!--Testing-->
         <dependency>

--- a/src/main/java/org/aerogear/digger/client/DiggerClient.java
+++ b/src/main/java/org/aerogear/digger/client/DiggerClient.java
@@ -157,6 +157,53 @@ public class DiggerClient {
     }
 
     /**
+     * Create new Digger job on Jenkins platform
+     *
+     * @param name      job name that can be used later to reference job
+     * @param gitRepo   git repository url (full git repository url. e.g git@github.com:wtrocki/helloworld-android-gradle.git
+     * @param gitBranch git repository branch (default branch used to checkout source code)
+     * @throws DiggerClientException if something goes wrong
+     */
+    public void updateJob(String name, String gitRepo, String gitBranch) throws DiggerClientException {
+        try {
+            jobService.update(this.jenkinsServer, name, gitRepo, gitBranch);
+        } catch (Throwable e) {
+            throw new DiggerClientException(e);
+        }
+    }
+
+    /**
+     * Update parameterized Digger job on Jenkins platform.
+     *
+     * @param name            job name that can be used later to reference job
+     * @param gitRepo         git repository url (full git repository url. e.g git@github.com:wtrocki/helloworld-android-gradle.git
+     * @param gitBranch       git repository branch (default branch used to checkout source code)
+     * @param buildParameters list of parameters for a Jenkins parameterized build.
+     * @throws DiggerClientException if something goes wrong
+     */
+    public void updateJob(String name, String gitRepo, String gitBranch, List<BuildParameter> buildParameters) throws DiggerClientException {
+        try {
+            jobService.update(this.jenkinsServer, name, gitRepo, gitBranch, buildParameters);
+        } catch (Throwable e) {
+            throw new DiggerClientException(e);
+        }
+    }
+
+    /**
+     * Get a Digger job on the Jenkins platform. Null if not found.
+     *
+     * @param name name of the job to get
+     * @throws DiggerClientException if something goes wrong
+     */
+     public void getJob(String name) throws DiggerClientException {
+        try {
+            jobService.get(this.jenkinsServer, name);
+        } catch (Throwable e) {
+            throw new DiggerClientException(e);
+        }
+     }
+
+    /**
      * Triggers a build for the given job and waits until it leaves the queue and actually starts.
      * <p>
      * Jenkins puts the build requests in a queue and once there is a slave available, it starts building

--- a/src/main/java/org/aerogear/digger/client/DiggerClient.java
+++ b/src/main/java/org/aerogear/digger/client/DiggerClient.java
@@ -157,7 +157,7 @@ public class DiggerClient {
     }
 
     /**
-     * Create new Digger job on Jenkins platform
+     * Update a Digger job on Jenkins platform
      *
      * @param name      job name that can be used later to reference job
      * @param gitRepo   git repository url (full git repository url. e.g git@github.com:wtrocki/helloworld-android-gradle.git
@@ -195,9 +195,9 @@ public class DiggerClient {
      * @param name name of the job to get
      * @throws DiggerClientException if something goes wrong
      */
-     public void getJob(String name) throws DiggerClientException {
+     public JobWithDetails getJob(String name) throws DiggerClientException {
         try {
-            jobService.get(this.jenkinsServer, name);
+            return jobService.get(this.jenkinsServer, name);
         } catch (Throwable e) {
             throw new DiggerClientException(e);
         }

--- a/src/main/java/org/aerogear/digger/client/model/BuildParameter.java
+++ b/src/main/java/org/aerogear/digger/client/model/BuildParameter.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aerogear.digger.client.model;
+
+/**
+ * Represents a parameter setting on a parameterized build in Jenkins.
+ * <p>
+ * This entity does should be used when creating a job. It should not
+ * be used to pass parameters to a build when triggering a build.
+ **/
+public class BuildParameter {
+
+  private String name;
+  private String description;
+  private String defaultValue;
+  
+  public BuildParameter(String name) {
+    this.name = name;
+    this.description = "";
+    this.defaultValue = "";
+  }
+
+  /**
+    * @return Updated build parameter
+    */
+  public BuildParameter setName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+    * @return Updated build parameter
+    */
+  public BuildParameter setDescription(String description) {
+    this.description = description;
+    return this;
+  }
+
+  /**
+    * @return Updated build parameter
+    */
+  public BuildParameter setDefaultValue(String defaultValue) {
+    this.defaultValue = defaultValue;
+    return this;
+  }
+
+  /**
+    * @return Name of the build parameter
+    */
+  public String getName() {
+    return this.name;
+  }
+
+  /**
+    * @return Description of the build parameter
+    */
+  public String getDescription() {
+    return this.description;
+  }
+
+  /**
+    * @return Default value of the build parameter
+    */
+  public String getDefaultValue() {
+    return this.defaultValue;
+  }
+}

--- a/src/main/java/org/aerogear/digger/client/services/BuildService.java
+++ b/src/main/java/org/aerogear/digger/client/services/BuildService.java
@@ -15,6 +15,7 @@
  */
 package org.aerogear.digger.client.services;
 
+import org.apache.commons.collections4.MapUtils;
 import com.offbytwo.jenkins.JenkinsServer;
 import com.offbytwo.jenkins.model.*;
 import org.aerogear.digger.client.DiggerClient;
@@ -147,7 +148,7 @@ public class BuildService {
             throw new IllegalArgumentException("Unable to find job for name '" + jobName + "'");
         }
 
-        final QueueReference queueReference = params == null ? job.build() : job.build(params);
+        final QueueReference queueReference = MapUtils.isEmpty(params) ? job.build() : job.build(params);
         if (queueReference == null) {
             // this is probably an implementation problem we have here
             LOG.debug("Queue reference cannot be null!");

--- a/src/main/java/org/aerogear/digger/client/services/BuildService.java
+++ b/src/main/java/org/aerogear/digger/client/services/BuildService.java
@@ -25,7 +25,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -122,17 +124,18 @@ public class BuildService {
     }
 
     /**
-     * See the documentation in {@link DiggerClient#build(String, long)}
+     * See the documentation in {@link DiggerClient#build(String, long, Map)}
      *
      * @param jenkinsServer Jenkins server client
      * @param jobName       name of the job
      * @param timeout       timeout
+     * @param params        build parameters to override defaults in the job
      * @return the build status
      * @throws IOException          if connection problems occur during connecting to Jenkins
      * @throws InterruptedException if a problem occurs during sleeping between checks
-     * @see DiggerClient#build(String, long)
+     * @see DiggerClient#build(String, long, Map)
      */
-    public BuildTriggerStatus build(JenkinsServer jenkinsServer, String jobName, long timeout) throws IOException, InterruptedException {
+    public BuildTriggerStatus build(JenkinsServer jenkinsServer, String jobName, long timeout, Map<String, String> params) throws IOException, InterruptedException {
         final long whenToTimeout = System.currentTimeMillis() + timeout;
 
         LOG.debug("Going to build job with name: {}", jobName);
@@ -144,7 +147,7 @@ public class BuildService {
             throw new IllegalArgumentException("Unable to find job for name '" + jobName + "'");
         }
 
-        final QueueReference queueReference = job.build();
+        final QueueReference queueReference = params == null ? job.build() : job.build(params);
         if (queueReference == null) {
             // this is probably an implementation problem we have here
             LOG.debug("Queue reference cannot be null!");
@@ -199,5 +202,20 @@ public class BuildService {
                 }
             }
         }
+    }
+
+    /**
+     * See the documentation in {@link DiggerClient#build(String, long)}
+     *
+     * @param jenkinsServer Jenkins server client
+     * @param jobName       name of the job
+     * @param timeout       timeout
+     * @return the build status
+     * @throws IOException          if connection problems occur during connecting to Jenkins
+     * @throws InterruptedException if a problem occurs during sleeping between checks
+     * @see DiggerClient#build(String, long)
+     */
+    public BuildTriggerStatus build(JenkinsServer jenkinsServer, String jobName, long timeout) throws IOException, InterruptedException {
+        return this.build(jenkinsServer, jobName, timeout, null);
     }
 }

--- a/src/main/java/org/aerogear/digger/client/services/JobService.java
+++ b/src/main/java/org/aerogear/digger/client/services/JobService.java
@@ -15,11 +15,14 @@
  */
 package org.aerogear.digger.client.services;
 
+import org.aerogear.digger.client.model.BuildParameter;
+
 import com.offbytwo.jenkins.JenkinsServer;
 import org.jtwig.JtwigModel;
 import org.jtwig.JtwigTemplate;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Create digger job on jenkins platform
@@ -28,19 +31,39 @@ public class JobService {
 
     private final static String GIT_REPO_URL = "GIT_REPO_URL";
     private final static String GIT_REPO_BRANCH = "GIT_REPO_BRANCH";
+    private final static String BUILD_PARAMETERS = "BUILD_PARAMETERS";
     private static final String JOB_TEMPLATE_PATH = "templates/job.xml";
 
     /**
      * Create new digger job on jenkins platform
      *
+     * @param jenkinsServer   Jenkins server client
+     * @param name            job name that can be used later to reference job
+     * @param gitRepo         git repository url (full git repository url. e.g git@github.com:digger/helloworld.git
+     * @param gitBranch       git repository branch (default branch used to checkout source code)
+     * @param buildParameters list of build parameters for the a parameterized job.
+     * @throws IOException
+     */
+    public void create(JenkinsServer jenkinsServer, String name, String gitRepo, String gitBranch, List<BuildParameter> buildParameters) throws IOException {
+        JtwigTemplate template = JtwigTemplate.classpathTemplate(JOB_TEMPLATE_PATH);
+        JtwigModel model = JtwigModel.newModel()
+            .with(GIT_REPO_URL, gitRepo)
+            .with(GIT_REPO_BRANCH, gitBranch)
+            .with(BUILD_PARAMETERS, buildParameters);
+        jenkinsServer.createJob(name, template.render(model));
+    }
+
+    /**
+     * Create new digger job on jenkins platform with no parameters.
+     *
      * @param jenkinsServer Jenkins server client
      * @param name          job name that can be used later to reference job
      * @param gitRepo       git repository url (full git repository url. e.g git@github.com:digger/helloworld.git
      * @param gitBranch     git repository branch (default branch used to checkout source code)
+     * @throws IOException          
+     * @see JobService#create(JenkinsServer, String, String, String, List)
      */
     public void create(JenkinsServer jenkinsServer, String name, String gitRepo, String gitBranch) throws IOException {
-        JtwigTemplate template = JtwigTemplate.classpathTemplate(JOB_TEMPLATE_PATH);
-        JtwigModel model = JtwigModel.newModel().with(GIT_REPO_URL, gitRepo).with(GIT_REPO_BRANCH, gitBranch);
-        jenkinsServer.createJob(name, template.render(model));
+        this.create(jenkinsServer, name, gitRepo, gitBranch, null);
     }
 }

--- a/src/main/java/org/aerogear/digger/client/services/JobService.java
+++ b/src/main/java/org/aerogear/digger/client/services/JobService.java
@@ -18,6 +18,7 @@ package org.aerogear.digger.client.services;
 import org.aerogear.digger.client.model.BuildParameter;
 
 import com.offbytwo.jenkins.JenkinsServer;
+import com.offbytwo.jenkins.model.JobWithDetails;
 import org.jtwig.JtwigModel;
 import org.jtwig.JtwigTemplate;
 
@@ -33,6 +34,18 @@ public class JobService {
     private final static String GIT_REPO_BRANCH = "GIT_REPO_BRANCH";
     private final static String BUILD_PARAMETERS = "BUILD_PARAMETERS";
     private static final String JOB_TEMPLATE_PATH = "templates/job.xml";
+
+    /**
+     * Get a digger job on jenkins platform.
+     *
+     * @param jenkinsServer Jenkins server client
+     * @param name          name of the job to retrieve
+     * @return job from Jenkins platform or null if not found
+     * @throws IOException
+     */
+    public JobWithDetails get(JenkinsServer jenkinsServer, String name) throws IOException {
+        return jenkinsServer.getJob(name);
+    }
 
     /**
      * Create new digger job on jenkins platform
@@ -60,10 +73,42 @@ public class JobService {
      * @param name          job name that can be used later to reference job
      * @param gitRepo       git repository url (full git repository url. e.g git@github.com:digger/helloworld.git
      * @param gitBranch     git repository branch (default branch used to checkout source code)
-     * @throws IOException          
-     * @see JobService#create(JenkinsServer, String, String, String, List)
+     * @throws IOException
+     * @see #create(JenkinsServer, String, String, String, List)
      */
     public void create(JenkinsServer jenkinsServer, String name, String gitRepo, String gitBranch) throws IOException {
         this.create(jenkinsServer, name, gitRepo, gitBranch, null);
+    }
+
+    /**
+     * Update digger job ob jenkins platform.
+     *
+     * @param jenkinsServer   Jenkins server client
+     * @param name            job name that can be used later to reference job
+     * @param gitRepo         git repository url (full git repository url. e.g git@github.com:digger/helloworld.git
+     * @param gitBranch       git repository branch (default branch used to checkout source code)
+     * @param buildParameters list of build parameters for the a parameterized job.
+     */
+    public void update(JenkinsServer jenkinsServer, String name, String gitRepo, String gitBranch, List<BuildParameter> buildParameters) throws IOException {
+        JtwigTemplate template = JtwigTemplate.classpathTemplate(JOB_TEMPLATE_PATH);
+        JtwigModel model = JtwigModel.newModel()
+            .with(GIT_REPO_URL, gitRepo)
+            .with(GIT_REPO_BRANCH, gitBranch)
+            .with(BUILD_PARAMETERS, buildParameters);
+        jenkinsServer.updateJob(name, template.render(model));
+    }
+
+    /**
+     *  Update digger job ob jenkins platform with no parameters.
+     *
+     * @param jenkinsServer Jenkins server client
+     * @param name          job name that can be used later to reference job
+     * @param gitRepo       git repository url (full git repository url. e.g git@github.com:digger/helloworld.git
+     * @param gitBranch     git repository branch (default branch used to checkout source code)
+     * @throws IOException
+     * @see #update(JenkinsServer, String, String, String, List)
+     */
+    public void update(JenkinsServer jenkinsServer, String name, String gitRepo, String gitBranch) throws IOException {
+        this.update(jenkinsServer, name, gitRepo, gitBranch, null);
     }
 }

--- a/src/main/resources/templates/job.xml
+++ b/src/main/resources/templates/job.xml
@@ -2,7 +2,7 @@
     <description/>
     <keepDependencies>false</keepDependencies>
     <properties>
-        {% if (BUILD_PARAMETERS is defined) %}
+        {% if BUILD_PARAMETERS %}
             <hudson.model.ParametersDefinitionProperty>
                 <parameterDefinitions>
                     {% for parameter in BUILD_PARAMETERS %}

--- a/src/main/resources/templates/job.xml
+++ b/src/main/resources/templates/job.xml
@@ -2,6 +2,19 @@
     <description/>
     <keepDependencies>false</keepDependencies>
     <properties>
+        {% if (BUILD_PARAMETERS is defined) %}
+            <hudson.model.ParametersDefinitionProperty>
+                <parameterDefinitions>
+                    {% for parameter in BUILD_PARAMETERS %}
+                        <hudson.model.StringParameterDefinition>
+                            <name>{{ parameter.name }}</name>
+                            <description>{{ parameter.description }}</description>
+                            <defaultValue>{{ parameter.defaultValue }}</defaultValue>
+                        </hudson.model.StringParameterDefinition>
+                    {% endfor %}
+                </parameterDefinitions>
+            </hudson.model.ParametersDefinitionProperty>
+        {% endif %}
         <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
             <triggers/>
         </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>

--- a/src/test/java/org/aerogear/digger/client/services/ArtifactsServiceTest.java
+++ b/src/test/java/org/aerogear/digger/client/services/ArtifactsServiceTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ArtifactsServiceTests {
+public class ArtifactsServiceTest {
 
     @Mock
     private JenkinsServer server;

--- a/src/test/java/org/aerogear/digger/client/services/JobServiceTest.java
+++ b/src/test/java/org/aerogear/digger/client/services/JobServiceTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class JobServiceTests {
+public class JobServiceTest {
 
     @Mock
     private JenkinsServer server;

--- a/src/test/java/org/aerogear/digger/client/services/JobServiceTest.java
+++ b/src/test/java/org/aerogear/digger/client/services/JobServiceTest.java
@@ -51,4 +51,21 @@ public class JobServiceTest {
         verify(server, times(1)).createJob(anyString(), anyString());
     }
 
+    @Test
+    public void shouldUpdateJob() throws Exception {
+        JobWithDetails job = mock(JobWithDetails.class);
+        BuildWithDetails build = mock(BuildWithDetails.class);
+        when(job.getBuildByNumber(anyInt())).thenReturn(build);
+        when(build.details()).thenReturn(build);
+        jobService.update(server, "name", "repo", "branch");
+        verify(server, times(1)).updateJob(anyString(), anyString());
+    }
+
+    @Test
+    public void shouldGetJob() throws Exception {
+        JobWithDetails job = mock(JobWithDetails.class);
+        BuildWithDetails build = mock(BuildWithDetails.class);
+        jobService.get(server, "name");
+        verify(server, times(1)).getJob(anyString());
+    }
 }


### PR DESCRIPTION
Based on the suggestions in [this comment.](https://issues.jboss.org/browse/AGDIGGER-73?focusedCommentId=13413453&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13413453)

This basically allows for parameterized builds through the DiggerClient so we can provide information such as the and to be able to update

## https://github.com/aerogear/digger-java/commit/6c23921a101e123840cb80d669597f207d2f6314
This change allows parameters to be defined when creating a Job,
allowing for parameterized builds to be performed. This is done
by providing a fourth parameter to diggerClient.createJob(), a
List of BuildParameter objects.

The BuildParameter contains the name of the parameter, the description
for the parameter and the default value for the parameter.

The builds can then be overridden when calling diggerClient.build()
by providing a third parameter, a Map containing the name of the
parameter as the key and the value of the parameter as the value.

The job.xml file has also been updated to loop through the list
of parameters if they are provided and add these to the config
file.

Currently only String type parameters are supported.

## https://github.com/aerogear/digger-java/commit/d02d36d8a66c456549d0ec40cbfcf34575309fbe
Allow for digger jobs to be retrieved and updated through the
DiggerClient.

This will allow for a user to be able to determine whether a job
has already been created before calling diggerClient.createJob()
or diggerClient.updateJob().
