### PR TITLE
 ✨ add support for streaming build logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
             <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>17.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/org/aerogear/digger/client/DiggerClient.java
+++ b/src/main/java/org/aerogear/digger/client/DiggerClient.java
@@ -20,6 +20,7 @@ import com.offbytwo.jenkins.model.BuildWithDetails;
 import com.offbytwo.jenkins.model.JobWithDetails;
 import org.aerogear.digger.client.model.BuildTriggerStatus;
 import org.aerogear.digger.client.model.BuildParameter;
+import org.aerogear.digger.client.model.LogStreamingOptions;
 import org.aerogear.digger.client.services.ArtifactsService;
 import org.aerogear.digger.client.services.BuildService;
 import org.aerogear.digger.client.services.JobService;
@@ -321,5 +322,19 @@ public class DiggerClient {
      */
     public List<BuildWithDetails> getBuildHistory(String jobName) throws DiggerClientException {
         return buildService.getBuildHistory(jenkinsServer, jobName);
+    }
+
+    /**
+     * Streaming the build logs.
+     *
+     * @param jobName the job name
+     * @param buildNumber the build number
+     * @param options See {@link LogStreamingOptions}
+     * @throws DiggerClientException
+     * @throws InterruptedException
+     * @throws IOException
+     */
+    public void streamLogs(String jobName, int buildNumber, LogStreamingOptions options) throws DiggerClientException, InterruptedException, IOException {
+        buildService.streamBuildLogs(jenkinsServer, jobName, buildNumber, options);
     }
 }

--- a/src/main/java/org/aerogear/digger/client/model/LogStreamingOptions.java
+++ b/src/main/java/org/aerogear/digger/client/model/LogStreamingOptions.java
@@ -1,0 +1,68 @@
+package org.aerogear.digger.client.model;
+
+import com.offbytwo.jenkins.helper.BuildConsoleStreamListener;
+
+/**
+ * Class to control the behavior of build logs streaming.
+ */
+public class LogStreamingOptions {
+
+    /**
+     * Polling interval. Default to 5 seconds.
+     */
+    private int pollingInterval = 5;
+
+    /**
+     * Polling timeout. Default to 1 hour.
+     */
+    private int pollingTimeout = 60*60;
+
+    /**
+     * Listener of streaming events.
+     */
+    private BuildConsoleStreamListener streamListener;
+
+    /**
+     * Constructor. Create with a listener
+     * @param streamListener the listener to receive log data.
+     */
+    public LogStreamingOptions(BuildConsoleStreamListener streamListener) {
+        this.streamListener = streamListener;
+    }
+
+    /**
+     * Constructor. Create with a listener, polling interval and polling timeout values.
+     * @param streamListener the listener to receive log data.
+     * @param pollingInterval in seconds
+     * @param pollingTimeout in seconds
+     */
+    public LogStreamingOptions(BuildConsoleStreamListener streamListener, int pollingInterval, int pollingTimeout) {
+        this.streamListener = streamListener;
+        this.pollingInterval = pollingInterval;
+        this.pollingTimeout = pollingTimeout;
+    }
+
+    public int getPollingInterval() {
+        return pollingInterval;
+    }
+
+    public void setPollingInterval(int pollingInterval) {
+        this.pollingInterval = pollingInterval;
+    }
+
+    public int getPollingTimeout() {
+        return pollingTimeout;
+    }
+
+    public void setPollingTimeout(int pollingTimeout) {
+        this.pollingTimeout = pollingTimeout;
+    }
+
+    public BuildConsoleStreamListener getStreamListener() {
+        return streamListener;
+    }
+
+    public void setStreamListener(BuildConsoleStreamListener streamListener) {
+        this.streamListener = streamListener;
+    }
+}

--- a/src/main/java/org/aerogear/digger/client/model/LogStreamingOptions.java
+++ b/src/main/java/org/aerogear/digger/client/model/LogStreamingOptions.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.aerogear.digger.client.model;
 
 import com.offbytwo.jenkins.helper.BuildConsoleStreamListener;

--- a/src/test/java/org/aerogear/digger/client/services/BuildServiceTest.java
+++ b/src/test/java/org/aerogear/digger/client/services/BuildServiceTest.java
@@ -17,8 +17,10 @@ package org.aerogear.digger.client.services;
 
 import com.google.common.collect.Lists;
 import com.offbytwo.jenkins.JenkinsServer;
+import com.offbytwo.jenkins.helper.BuildConsoleStreamListener;
 import com.offbytwo.jenkins.model.*;
 import org.aerogear.digger.client.model.BuildTriggerStatus;
+import org.aerogear.digger.client.model.LogStreamingOptions;
 import org.aerogear.digger.client.util.DiggerClientException;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
@@ -199,6 +202,33 @@ public class BuildServiceTest {
         assertThat(detailsList).hasSize(2);
         assertThat(detailsList.get(0)).isSameAs(buildDetails1);
         assertThat(detailsList.get(1)).isSameAs(buildDetails2);
+    }
+
+
+    @Test
+    public void shouldStreamBuildLogs() throws Exception {
+        JobWithDetails job = mock(JobWithDetails.class);
+        Build build = mock(Build.class);
+        BuildWithDetails buildDetails = mock(BuildWithDetails.class);
+
+        when(jenkinsServer.getJob(anyString())).thenReturn(job);
+        when(job.getBuildByNumber(anyInt())).thenReturn(build);
+        when(build.details()).thenReturn(buildDetails);
+
+        LogStreamingOptions options = new LogStreamingOptions(new BuildConsoleStreamListener() {
+            @Override
+            public void onData(String s) {
+
+            }
+
+            @Override
+            public void finished() {
+
+            }
+        });
+
+        service.streamBuildLogs(jenkinsServer, "some-job", 1, options);
+        verify(buildDetails).streamConsoleOutput(options.getStreamListener(), options.getPollingInterval(), options.getPollingTimeout());
     }
 
 }


### PR DESCRIPTION
This PR will add support for steaming build logs.

It also uses the 0.3.8-SNAPSHOT release of the Jenkins java client module. You may need to run this command to compile:

```
mvn clean install -U
```

ping @aliok @odra @aidenkeating @luigizuccarelli for review