### PR TITLE
add a new method to return the jenkins server client instance

### DIFF
--- a/src/main/java/org/aerogear/digger/client/DiggerClient.java
+++ b/src/main/java/org/aerogear/digger/client/DiggerClient.java
@@ -385,4 +385,12 @@ public class DiggerClient {
     public BuildWithDetails getBuildDetails(String jobName, int buildNumber) throws DiggerClientException {
         return buildService.getBuildDetails(jenkinsServer, jobName, buildNumber);
     }
+
+    /**
+     * Expose the underline Jenkins Server client to allow perform other operations that may not be implemented by the jenkins digger client.
+     * @return the instance of the jenkins server
+     */
+    public JenkinsServer getJenkinsServer() {
+        return this.jenkinsServer;
+    }
 }


### PR DESCRIPTION
## Motivation

Sometimes we need to use the jenkins client to perform some operations that are not supported by the digger java client.

For example, for the android build to work on RHMAP, we want to create a new Jenkins credential so that it can be used by the android signing plugin to sign android release builds. We could add another parameter to the `build` method to pass in the credential, but some other users may choose not to use this approach. The best thing here is to just expose the jenkins client and that will give user more options to configure the jenkins server before(or after) a build.

## Changes

Adding a new method that will return the jenkins client instance.