### PR TITLE
 🔖 bump version on master. Prepare for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.jboss.aerogear</groupId>
     <artifactId>digger-java-client</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
Needs to bump the version to 1.0.2-SNAPSHOT for master. The problem is that because there is breaking changes in the changes, we need to release a new version (1.0.0-SNAPSHOT) for the 3.18.0 release. To avoid confusion, let's bump the version to 1.0.2-SNAPSHOT on master.

ping @aliok @matzew to review.

@matzew Can you please create a new release (1.0.2) from master after this one is merged? Looks like you are the only one with the permission to do it.