### PR TITLE
added functionality to retrieve queue

### DIFF
--- a/src/main/java/org/aerogear/digger/client/model/BuildTriggerStatus.java
+++ b/src/main/java/org/aerogear/digger/client/model/BuildTriggerStatus.java
@@ -15,6 +15,8 @@
  */
 package org.aerogear.digger.client.model;
 
+import com.offbytwo.jenkins.model.QueueReference;
+
 /**
  * Represents the status of a build that is just triggered.
  * <p>
@@ -47,15 +49,22 @@ public class BuildTriggerStatus {
         /**
          * The build is stuck on Jenkins queue.
          */
-        STUCK_IN_QUEUE
+        STUCK_IN_QUEUE,
+
+        /**
+         * The build is just added to the Jenkins queue.
+         */
+        TRIGGERED
     }
 
     private final State state;
     private final int buildNumber;
+    private final QueueReference queueReference;
 
-    public BuildTriggerStatus(State state, int buildNumber) {
+    public BuildTriggerStatus(State state, int buildNumber, QueueReference queueReference) {
         this.state = state;
         this.buildNumber = buildNumber;
+        this.queueReference = queueReference;
     }
 
     /**
@@ -73,6 +82,10 @@ public class BuildTriggerStatus {
      */
     public int getBuildNumber() {
         return buildNumber;
+    }
+
+    public QueueReference getQueueReference() {
+        return queueReference;
     }
 
     @Override


### PR DESCRIPTION
Changes:

Refactored code to allow the retrieval of the queue reference to millicore.

Verification:
We need to test new functionality which split out the polling and the triggering of the build from the one build method.
We can now directly call triggerBuild() & pollBuild(). The api of the existing build() method was not changed and should work as previous.

To test: Add this unit test to BuildServiceTest.java : 

``` Java
@Test
    public void shouldTriggerBuildTest() throws Exception {
        DiggerClient diggerClient = DiggerClient.createDefaultWithAuth("JENKINS_URL", "admin", "password");
        Map<String, String> params = new HashMap<String, String>();
        params.put("BRANCH", "master");
        params.put("PLATFORM", "android");
        params.put("FH_CONFIG_CONTENT", "foo");
        params.put("BUILD_CREDENTIAL_ID", "bar");
        params.put("BUILD_CREDENTIAL_ALIAS", "foo");
        params.put("BUILD_CONFIG", "debug");
        String jobName = "JOB_NAME";
        BuildTriggerStatus buildTriggerStatus = diggerClient.triggerBuild(jobName, params);
        diggerClient.pollBuild(jobName, buildTriggerStatus.getQueueReference(), DiggerClient.DEFAULT_BUILD_TIMEOUT, params);
        //BuildTriggerStatus buildTriggerStatus = diggerClient.build(jobName, DiggerClient.DEFAULT_BUILD_TIMEOUT, params);
        diggerClient.cancelBuild(jobName, buildTriggerStatus.getBuildNumber());
    }
```

1. Breakpoint the test at the last line as we want to trigger the build and see it on jenkins & run it in debug
2. On confirming the build is triggered - click through and cancel the build - (Build should cancel successfully)
3. Comment out the  lines which execute diggerClient.triggerBuild & diggerClient.pollBuild & uncomment the diggerClient.build line and run in debug.
4. Ensure the build is triggered on jenkins and then step through to cancel the build (Build should cancel successfully)

This will test that the build method worked as before and we can separately call triggerBuild and pollBuild 
